### PR TITLE
SAD-503 Remove file nesting from default workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,15 +73,5 @@
     "onSave": "test-file"
   },
   "xmlTools.splitAttributesOnFormat": false,
-  "xmlTools.enforcePrettySelfClosingTagOnFormat": true,
-  "explorer.fileNesting.enabled": true,
-  "explorer.fileNesting.patterns": {
-    "*.ts": "${capture}.js,${capture}.test.ts",
-    "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
-    "*.jsx": "${capture}.js",
-    "*.tsx": "${capture}.ts, ${capture}.test.tsx, ${capture}.module.scss",
-    "tsconfig.json": "tsconfig.*.json",
-    "package.json": "package-lock.json, yarn.lock"
-  },
-  "explorer.fileNesting.expand": true
+  "xmlTools.enforcePrettySelfClosingTagOnFormat": true
 }


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/SAD-503

This will stop files from being nested in the VSCode explorer by default. If you want it back, you can always add it to your user settings instead - details are in the ticket.